### PR TITLE
Update packaging for Windows

### DIFF
--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -68,6 +68,7 @@ stages:
             parameters:
               suffix: 'windows'
               zipcommand: "7z a"
+              useMinGW: true
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "packages/"

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -63,7 +63,7 @@ stages:
             parameters:
               suffix: 'windows'
               zipcommand: "7z a"
-              useMinGW: true
+              packageMinGWLibs: true
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "packages/"

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -63,6 +63,7 @@ stages:
             parameters:
               suffix: 'windows'
               zipcommand: "7z a"
+              useMinGW: true
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "packages/"

--- a/.azure-pipelines/templates/package-binaries.yml
+++ b/.azure-pipelines/templates/package-binaries.yml
@@ -13,7 +13,7 @@ steps:
       cp $MINGWLIB\libquadmath-0.dll bin/
       cp $MINGWLIB\libwinpthread-1.dll bin/
       cp $MINGWLIB\libgcc_s_seh-1.dll bin/
-    condition: eq('${{ parameters.useMinGW }}', true)
+    condition: eq('${{ parameters.packageMinGWLibs }}', true)
     displayName: 'Package MinGW Libs'
   - bash: |
       set -ex

--- a/.azure-pipelines/templates/package-binaries.yml
+++ b/.azure-pipelines/templates/package-binaries.yml
@@ -11,7 +11,7 @@ steps:
       set -ex
       VERSION=$(cat version)
       if [[ "${{ parameters.useMinGW }}" == "true" ]]; then
-        MINGWLIB="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin\"
+        MINGWLIB="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin\\"
         cp $MINGWLIB\libquadmath-0.dll bin/
         cp $MINGWLIB\libwinpthread-1.dll bin/
         cp $MINGWLIB\libgcc_s_seh-1.dll bin/

--- a/.azure-pipelines/templates/package-binaries.yml
+++ b/.azure-pipelines/templates/package-binaries.yml
@@ -5,6 +5,7 @@ parameters:
     default: "zip -9rv"
   - name: useMinGW
     default: false
+    type: boolean
 
 steps:
   - bash: |

--- a/.azure-pipelines/templates/package-binaries.yml
+++ b/.azure-pipelines/templates/package-binaries.yml
@@ -3,7 +3,7 @@ parameters:
     default: linux
   - name: zipcommand
     default: "zip -9rv"
-  - name: useMinGW
+  - name: packageMinGWLibs
     default: false
     type: boolean
 
@@ -11,7 +11,7 @@ steps:
   - bash: |
       set -ex
       VERSION=$(cat version)
-      if [[ "${{ parameters.useMinGW }}" == "true" ]]; then
+      if [[ "${{ parameters.packageMinGWLibs }}" == "true" ]]; then
         MINGWLIB="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin\\"
         cp $MINGWLIB\libquadmath-0.dll bin/
         cp $MINGWLIB\libwinpthread-1.dll bin/

--- a/.azure-pipelines/templates/package-binaries.yml
+++ b/.azure-pipelines/templates/package-binaries.yml
@@ -15,7 +15,6 @@ steps:
         cp $MINGWLIB\libquadmath-0.dll bin/
         cp $MINGWLIB\libwinpthread-1.dll bin/
         cp $MINGWLIB\libgcc_s_seh-1.dll bin/
-        cp $MINGWLIB\libgcc_s_dw2-1.dll bin/
       fi
       mkdir binaries-${VERSION}-${{ parameters.suffix }}
       cp bin/* binaries-${VERSION}-${{ parameters.suffix }}

--- a/.azure-pipelines/templates/package-binaries.yml
+++ b/.azure-pipelines/templates/package-binaries.yml
@@ -11,7 +11,7 @@ steps:
       set -ex
       VERSION=$(cat version)
       if [[ "${{ parameters.useMinGW }}" == "true" ]]; then
-        MINGWLIB="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
+        MINGWLIB="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin\"
         cp $MINGWLIB\libquadmath-0.dll bin/
         cp $MINGWLIB\libwinpthread-1.dll bin/
         cp $MINGWLIB\libgcc_s_seh-1.dll bin/

--- a/.azure-pipelines/templates/package-binaries.yml
+++ b/.azure-pipelines/templates/package-binaries.yml
@@ -6,17 +6,18 @@ parameters:
   - name: packageMinGWLibs
     default: false
     type: boolean
-
 steps:
   - bash: |
       set -ex
+      MINGWLIB="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin\\"
+      cp $MINGWLIB\libquadmath-0.dll bin/
+      cp $MINGWLIB\libwinpthread-1.dll bin/
+      cp $MINGWLIB\libgcc_s_seh-1.dll bin/
+    condition: eq('${{ parameters.useMinGW }}', true)
+    displayName: 'Package MinGW Libs'
+  - bash: |
+      set -ex
       VERSION=$(cat version)
-      if [[ "${{ parameters.packageMinGWLibs }}" == "true" ]]; then
-        MINGWLIB="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin\\"
-        cp $MINGWLIB\libquadmath-0.dll bin/
-        cp $MINGWLIB\libwinpthread-1.dll bin/
-        cp $MINGWLIB\libgcc_s_seh-1.dll bin/
-      fi
       mkdir binaries-${VERSION}-${{ parameters.suffix }}
       cp bin/* binaries-${VERSION}-${{ parameters.suffix }}
       ${{ parameters.zipcommand }} binaries-${VERSION}-${{ parameters.suffix }}.zip binaries-${VERSION}-${{ parameters.suffix }}/

--- a/.azure-pipelines/templates/package-binaries.yml
+++ b/.azure-pipelines/templates/package-binaries.yml
@@ -10,8 +10,7 @@ steps:
   - bash: |
       set -ex
       VERSION=$(cat version)
-      if [ $USE_MIN_GW ]
-      then
+      if [[ "${{ parameters.useMinGW }}" == "true" ]]; then
         MINGWLIB="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
         cp $MINGWLIB\libquadmath-0.dll bin/
         cp $MINGWLIB\libwinpthread-1.dll bin/
@@ -21,8 +20,6 @@ steps:
       mkdir binaries-${VERSION}-${{ parameters.suffix }}
       cp bin/* binaries-${VERSION}-${{ parameters.suffix }}
       ${{ parameters.zipcommand }} binaries-${VERSION}-${{ parameters.suffix }}.zip binaries-${VERSION}-${{ parameters.suffix }}/
-    env:
-      USE_MIN_GW: ${{ parameters.useMinGW }}
     displayName: 'Create Binaries Zip'
   - bash: |
       set -ex

--- a/.azure-pipelines/templates/package-binaries.yml
+++ b/.azure-pipelines/templates/package-binaries.yml
@@ -3,14 +3,26 @@ parameters:
     default: linux
   - name: zipcommand
     default: "zip -9rv"
+  - name: useMinGW
+    default: false
 
 steps:
   - bash: |
       set -ex
       VERSION=$(cat version)
+      if [ $USE_MIN_GW ]
+      then
+        MINGWLIB="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
+        cp $MINGWLIB\libquadmath-0.dll bin/
+        cp $MINGWLIB\libwinpthread-1.dll bin/
+        cp $MINGWLIB\libgcc_s_seh-1.dll bin/
+        cp $MINGWLIB\libgcc_s_dw2-1.dll bin/
+      fi
       mkdir binaries-${VERSION}-${{ parameters.suffix }}
       cp bin/* binaries-${VERSION}-${{ parameters.suffix }}
       ${{ parameters.zipcommand }} binaries-${VERSION}-${{ parameters.suffix }}.zip binaries-${VERSION}-${{ parameters.suffix }}/
+    env:
+      USE_MIN_GW: ${{ parameters.useMinGW }}
     displayName: 'Create Binaries Zip'
   - bash: |
       set -ex

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,1 +1,0 @@
-Gudrun release 2021.1. This is the initial release of the Gudrun code (as of 15th July 2021) with binary packages built on Azure.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,0 +1,1 @@
+Gudrun release 2021.1. This is the initial release of the Gudrun code (as of 15th July 2021) with binary packages built on Azure.


### PR DESCRIPTION
Updated packaging process for Windows to include  MinGW libraries required to run the Gudrun binaries.
Libraries included in packaging:
- libgcc_s_seh-1
- libquadmath-0
- libwinpthread-1

These are pulled from the MinGW libraries during packaging, and zipped with the Gudrun binaries - which are then published as artefacts.