### PR TITLE
Redirect group calibration file

### DIFF
--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -19,7 +19,7 @@ steps:
       HDF5_DIR="$(pwd)/${{ parameters.hdf5tag }}"
       mkdir build
       cd build
-      cmake ../ -G Ninja ${{ parameters.extraflags }} -DLOCAL_STATIC_HDF5:bool=true -DHDF5_DIR:path=${HDF5_DIR}
+      cmake ../ -G Ninja ${{ parameters.extraflags }} -DLOCAL_STATIC_HDF5:bool=true -DHDF5_DIR:path=${HDF5_DIR} -DCMAKE_Fortran_FLAGS:string="-cpp" -DGUDPY_COMPATIBILITY=1
       ninja
       ninja install
     displayName: 'Build'

--- a/.azure-pipelines/templates/build-osx.yml
+++ b/.azure-pipelines/templates/build-osx.yml
@@ -20,7 +20,7 @@ steps:
       HDF5_DIR="$(pwd)/${{ parameters.hdf5tag }}"
       mkdir build
       cd build
-      cmake ../ -G Ninja -DCMAKE_Fortran_COMPILER:string="gfortran-9" -DLOCAL_STATIC_HDF5:bool=True -DHDF5_DIR:path=${HDF5_DIR} ${{ parameters.extraflags }}
+      cmake ../ -G Ninja -DCMAKE_Fortran_COMPILER:string="gfortran-9" -DLOCAL_STATIC_HDF5:bool=True -DHDF5_DIR:path=${HDF5_DIR} -DCMAKE_Fortran_FLAGS:string="-cpp" -DGUDPY_COMPATIBILITY=1 ${{ parameters.extraflags }}
       ninja
       ninja install
     displayName: 'Build'

--- a/.azure-pipelines/templates/build-windows.yml
+++ b/.azure-pipelines/templates/build-windows.yml
@@ -22,7 +22,7 @@ steps:
       HDF5_DIR="$(pwd)/${{ parameters.hdf5tag }}"
       mkdir build
       cd build
-      cmake ../ -G "MinGW Makefiles" -DLOCAL_STATIC_HDF5:bool=True -DHDF5_DIR:path=${HDF5_DIR} ${{ parameters.extraflags }}
+      cmake ../ -G "MinGW Makefiles" -DLOCAL_STATIC_HDF5:bool=True -DHDF5_DIR:path=${HDF5_DIR} -DCMAKE_Fortran_FLAGS:string="-cpp" -DGUDPY_COMPATIBILITY=1 ${{ parameters.extraflags }}
       cmake --build . --config Release
       cmake --install .
     displayName: 'Build'

--- a/src/neutron/libGudrunN/groups_routines.f90
+++ b/src/neutron/libGudrunN/groups_routines.f90
@@ -37,7 +37,7 @@ MODULE groups_routines
     integer, dimension(2)                   :: olddims,newdims
     integer                                 :: oldsize,newsize
     integer, dimension(:), allocatable      :: igroup_in
-    integer                                 :: start !start position to extract calibration filename from
+    integer                                 :: fname_start !start position to extract calibration filename from
 
     CONTAINS
     
@@ -464,14 +464,14 @@ MODULE groups_routines
         close (10)
 !c Write a file to store group calibration suitable to be read by Gudrun_GUI
             fname1=fname1(1:len_trim(fname1))//'.cal'
-            start=INDEX(fname1, "/", BACK=.TRUE.)
-            IF (start == 0 ) THEN
-                start=INDEX(fname1, "\", BACK=.TRUE.)
+            fname_start=INDEX(fname1, "/", BACK=.TRUE.)
+            IF (fname_start == 0 ) THEN
+                fname_start=INDEX(fname1, "\", BACK=.TRUE.)
             END IF
-            IF (start > 0) THEN
-                start=start+1
+            IF (fname_start > 0) THEN
+                fname_start=fname_start+1
             END IF
-            fname1=fname1(start:len_trim(fname1))
+            fname1=fname1(fname_start:len_trim(fname1))
         write(6,*) fname1
         open(10,file=fname1,status='unknown')
         do i=1,ngroup

--- a/src/neutron/libGudrunN/groups_routines.f90
+++ b/src/neutron/libGudrunN/groups_routines.f90
@@ -37,6 +37,7 @@ MODULE groups_routines
     integer, dimension(2)                   :: olddims,newdims
     integer                                 :: oldsize,newsize
     integer, dimension(:), allocatable      :: igroup_in
+    integer                                 :: start !start position to extract calibration filename from
 
     CONTAINS
     
@@ -463,6 +464,14 @@ MODULE groups_routines
         close (10)
 !c Write a file to store group calibration suitable to be read by Gudrun_GUI
             fname1=fname1(1:len_trim(fname1))//'.cal'
+            start=INDEX(fname1, "/", BACK=.TRUE.)
+            IF (start == 0 ) THEN
+                start=INDEX(fname1, "\", BACK=.TRUE.)
+            END IF
+            IF (start > 0) THEN
+                start=start+1
+            END IF
+            fname1=fname1(start:len_trim(fname1))
         write(6,*) fname1
         open(10,file=fname1,status='unknown')
         do i=1,ngroup

--- a/src/neutron/libGudrunN/groups_routines.f90
+++ b/src/neutron/libGudrunN/groups_routines.f90
@@ -464,14 +464,16 @@ MODULE groups_routines
         close (10)
 !c Write a file to store group calibration suitable to be read by Gudrun_GUI
             fname1=fname1(1:len_trim(fname1))//'.cal'
-            fname_start=INDEX(fname1, "/", BACK=.TRUE.)
-            IF (fname_start == 0 ) THEN
-                fname_start=INDEX(fname1, "\", BACK=.TRUE.)
-            END IF
-            IF (fname_start > 0) THEN
-                fname_start=fname_start+1
-            END IF
-            fname1=fname1(fname_start:len_trim(fname1))
+            #ifdef GUDPY_COMPATIBILITY
+                fname_start=INDEX(fname1, "/", BACK=.TRUE.)
+                IF (fname_start == 0 ) THEN
+                    fname_start=INDEX(fname1, "\", BACK=.TRUE.)
+                END IF
+                IF (fname_start > 0) THEN
+                    fname_start=fname_start+1
+                END IF
+                fname1=fname1(fname_start:len_trim(fname1))
+            #endif
         write(6,*) fname1
         open(10,file=fname1,status='unknown')
         do i=1,ngroup

--- a/src/neutron/libGudrunN/groups_routines.f90
+++ b/src/neutron/libGudrunN/groups_routines.f90
@@ -464,16 +464,16 @@ MODULE groups_routines
         close (10)
 !c Write a file to store group calibration suitable to be read by Gudrun_GUI
             fname1=fname1(1:len_trim(fname1))//'.cal'
-            #ifdef GUDPY_COMPATIBILITY
-                fname_start=INDEX(fname1, "/", BACK=.TRUE.)
-                IF (fname_start == 0 ) THEN
-                    fname_start=INDEX(fname1, "\", BACK=.TRUE.)
-                END IF
-                IF (fname_start > 0) THEN
-                    fname_start=fname_start+1
-                END IF
-                fname1=fname1(fname_start:len_trim(fname1))
-            #endif
+#ifdef GUDPY_COMPATIBILITY
+            fname_start=INDEX(fname1, "/", BACK=.TRUE.)
+            IF (fname_start == 0 ) THEN
+                fname_start=INDEX(fname1, "\", BACK=.TRUE.)
+            END IF
+            IF (fname_start > 0) THEN
+                fname_start=fname_start+1
+            END IF
+            fname1=fname1(fname_start:len_trim(fname1))
+#endif
         write(6,*) fname1
         open(10,file=fname1,status='unknown')
         do i=1,ngroup


### PR DESCRIPTION
This PR implements redirecting the group calibration file (`.dat.cal`/`.grp.cal`) to the input file directory, to prevent writing to the "StartupFiles" directory.