### PR TITLE
Enable Preprocessing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,6 @@ set(CMAKE_INSTALL_PREFIX
       FORCE)
 
 # Define compile flags and linker lines for builds
-set(CMAKE_Fortran_FLAGS_RELEASE " -funroll-all-loops -fno-f2c -O2")
+set(CMAKE_Fortran_FLAGS_RELEASE " -funroll-all-loops -fno-f2c -O2 -cpp")
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,15 @@ set(CMAKE_BUILD_TYPE "Release")
 include(ExternalProject)
 
 option(
+  GUDPY_COMPATIBILITY
+  "Enable some compatibility options with GudPy"
+  OFF)
+
+if(GUDPY_COMPATIBILITY)
+  add_definitions("-DGUDPY_COMPATIBILITY")
+endif(GUDPY_COMPATIBILITY)
+
+option(
   LOCAL_STATIC_HDF5
   "Use local HDF5 installation (specified with HDF5_DIR) built with static ZLIB and SZIP support (so don't search for them)"
   OFF)


### PR DESCRIPTION
Preprocessing (`#ifdef`) of some modified source files was broken because, contrary to the opinion of the internet, the `-cpp` switch is not always automatically enabled when compiling a `.f90` file.

This PR explicitly adds the flag to the compilation,