### PR TITLE
Fix Loop Limit in GetSect

### DIFF
--- a/src/neutron/libget/getsect.c
+++ b/src/neutron/libget/getsect.c
@@ -213,7 +213,8 @@ int GENIEMECHANISM fastget_init(const char* name, const int* iunit)
 	FOPEN_BUFFER_SIZE = (getenv("G_FOPEN_BUFFER_SIZE") != 0 ? atol(getenv("G_FOPEN_BUFFER_SIZE")) : BUFSIZ);
     }
 /* First null terminate our FORTRAN string */
-    for(i=119; name[i] == ' '; i--)
+/* Modified 12/22 by TGAY - Change loop limit from 119 to 255 for consistency with string variable declared size */
+    for(i=255; name[i] == ' '; i--)
 	;
     if (i < 0)
     {


### PR DESCRIPTION
This PR fixes a small bug in `getsect.c` which leads to filenames/paths being truncated to 120 characters, even though the limit is 256 (as dictated by the string sizes).