### PR TITLE
CI: Fix package binary location in publish workflow

### DIFF
--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -26,4 +26,4 @@ runs:
       run: |
         set -ex
         export GITHUB_TOKEN=${{ github.token }}
-        ./update-release -r disorderedmaterials/Gudrun -t ${{ env.gudrunVersion }} -n "${{ env.gudrunVersion }}" -f ReleaseNotes.md packages/*.zip startupFiles-*.zip
+        ./update-release -r disorderedmaterials/Gudrun -t ${{ env.gudrunVersion }} -n "${{ env.gudrunVersion }}" -f ReleaseNotes.md packages/*/*.zip startupFiles-*.zip


### PR DESCRIPTION
In the new version, the `download-artifact@v4` downloads each artifact in a folder of the same name which breaks the current publishing workflow. This PR adjusts the workflow to handle this change.