### PR TITLE
ci: Update MacOS runners in CI to accomodate GitHub Workflows Update

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -3,37 +3,36 @@ name: Continuous
 on:
   push:
     branches:
-    - 'main'
+      - "main"
     paths-ignore:
-    - '.github/workflows/pr.yml'
-    - '.github/workflows/release.yml'
-    - 'README.md'
+      - ".github/workflows/pr.yml"
+      - ".github/workflows/release.yml"
+      - "README.md"
 
 jobs:
-
   Build:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, macos-14, windows-latest ]
+        os: [macos-latest, macos-13, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set Environment Variables
-      uses: "./.github/workflows/setup"
-    - name: "Build (${{ matrix.os }})"
-      uses: "./.github/workflows/build"
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set Environment Variables
+        uses: "./.github/workflows/setup"
+      - name: "Build (${{ matrix.os }})"
+        uses: "./.github/workflows/build"
 
   PackageOSX:
-    needs: [ Build ]
+    needs: [Build]
     strategy:
       fail-fast: false
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set Environment Variables
-      uses: "./.github/workflows/setup"
-    - name: "Package OSX"
-      uses: "./.github/workflows/package"
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set Environment Variables
+        uses: "./.github/workflows/setup"
+      - name: "Package OSX"
+        uses: "./.github/workflows/package"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -28,7 +28,7 @@ jobs:
     needs: [Build]
     strategy:
       fail-fast: false
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -26,4 +26,4 @@ runs:
       run: |
         set -ex
         export GITHUB_TOKEN=${{ github.token }}
-        ./update-release -r disorderedmaterials/Gudrun -t ${{ env.gudrunVersion }} -n "${{ env.gudrunVersion }}" -f ReleaseNotes.md packages/*.zip startupFiles-*.zip
+        ./update-release -r disorderedmaterials/Gudrun -t ${{ env.gudrunVersion }} -n "${{ env.gudrunVersion }}" -f ReleaseNotes.md packages/*/*.zip startupFiles-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -28,7 +28,7 @@ jobs:
     needs: [Build]
     strategy:
       fail-fast: false
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Recent GitHub Update changed the macos-latest image to be macos 14 ARM64, affecting the current workflows.
This PR updates the workflows to accomodate this, to use macos-latest as the Sillicon runner and macos-13 as the intel runner.